### PR TITLE
module/ssh_k3s: we don't need no errors on uninstall

### DIFF
--- a/terraform/modules/ssh_k3s/main.tf
+++ b/terraform/modules/ssh_k3s/main.tf
@@ -46,6 +46,11 @@ module "k3s" {
   node_cidr_mask_size = var.node_cidr_mask_size
 }
 
+locals {
+  server_uninstall = "/usr/local/bin/k3s-uninstall.sh"
+  client_uninstall = "/usr/local/bin/k3s-agent-uninstall.sh"
+}
+
 resource "ssh_resource" "remove_k3s" {
   count = var.server_count + var.agent_count
 
@@ -56,6 +61,7 @@ resource "ssh_resource" "remove_k3s" {
 
   when = "destroy"
   commands = [
-    "sudo /usr/local/bin/k3s-*uninstall.sh"
+    "stat ${local.client_uninstall} && sudo ${local.client_uninstall} || true",
+    "stat ${local.server_uninstall} && sudo ${local.server_uninstall} || true",
   ]
 }

--- a/terraform/modules/ssh_k3s/main.tf
+++ b/terraform/modules/ssh_k3s/main.tf
@@ -49,6 +49,7 @@ module "k3s" {
 locals {
   server_uninstall = "/usr/local/bin/k3s-uninstall.sh"
   client_uninstall = "/usr/local/bin/k3s-agent-uninstall.sh"
+  k3s_killall = "/usr/local/bin/k3s-killall.sh"
 }
 
 resource "ssh_resource" "remove_k3s" {
@@ -61,6 +62,7 @@ resource "ssh_resource" "remove_k3s" {
 
   when = "destroy"
   commands = [
+    "stat ${local.k3s_killall} && sudo ${local.k3s_killall} || true",
     "stat ${local.client_uninstall} && sudo ${local.client_uninstall} || true",
     "stat ${local.server_uninstall} && sudo ${local.server_uninstall} || true",
   ]


### PR DESCRIPTION
Just ignore errors when any on of k3s server or agent uninstall scripts are missing.