### PR TITLE
Version and TF module updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ config/rke*
 
 bin/out.json
 bin/results.csv
+*.tfvars

--- a/bin/lib/rancher_monitoring.mjs
+++ b/bin/lib/rancher_monitoring.mjs
@@ -1,7 +1,7 @@
 import {helm_install} from "./common.mjs";
 
-const RANCHER_MONITORING_CHART = "https://github.com/rancher/charts/raw/release-v2.7/assets/rancher-monitoring/rancher-monitoring-102.0.0%2Bup40.1.2.tgz"
-const RANCHER_MONITORING_CRD_CHART = "https://github.com/rancher/charts/raw/release-v2.7/assets/rancher-monitoring-crd/rancher-monitoring-crd-102.0.0%2Bup40.1.2.tgz"
+const RANCHER_MONITORING_CHART = "https://github.com/rancher/charts/raw/release-v2.7/assets/rancher-monitoring/rancher-monitoring-102.0.1%2Bup40.1.2.tgz"
+const RANCHER_MONITORING_CRD_CHART = "https://github.com/rancher/charts/raw/release-v2.7/assets/rancher-monitoring-crd/rancher-monitoring-crd-102.0.1%2Bup40.1.2.tgz"
 
 export function install_rancher_monitoring(cluster, monitoringRestrictions, mimirUrl = null) {
     helm_install("rancher-monitoring-crd", RANCHER_MONITORING_CRD_CHART, cluster, "cattle-monitoring-system", {

--- a/bin/setup.mjs
+++ b/bin/setup.mjs
@@ -1,26 +1,26 @@
 #!/usr/bin/env node
 import {
-    ADMIN_PASSWORD,
-    dir,
-    terraformDir,
-    terraformVar,
-    helm_install,
-    q,
-    run,
-    runCollectingJSONOutput,
-    runCollectingOutput,
-    isK3d,
-    retryOnError,
+  ADMIN_PASSWORD,
+  dir,
+  terraformDir,
+  terraformVar,
+  helm_install,
+  q,
+  run,
+  runCollectingJSONOutput,
+  runCollectingOutput,
+  isK3d,
+  retryOnError,
 } from "./lib/common.mjs"
-import {k6_run} from "./lib/k6.mjs";
-import {install_rancher_monitoring} from "./lib/rancher_monitoring.mjs";
+import { k6_run } from "./lib/k6.mjs";
+import { install_rancher_monitoring } from "./lib/rancher_monitoring.mjs";
 
 // Parameters
 const RANCHER_VERSION = "2.7.6"
 const RANCHER_CHART = `https://releases.rancher.com/server-charts/latest/rancher-${RANCHER_VERSION}.tgz`
 const RANCHER_IMAGE_TAG = `v${RANCHER_VERSION}`
-const CERT_MANAGER_CHART = "https://charts.jetstack.io/charts/cert-manager-v1.8.0.tgz"
-const GRAFANA_CHART = "https://github.com/grafana/helm-charts/releases/download/grafana-6.56.5/grafana-6.56.5.tgz"
+const CERT_MANAGER_CHART = "https://charts.jetstack.io/charts/cert-manager-v1.11.1.tgz"
+const GRAFANA_CHART = "https://github.com/grafana/helm-charts/releases/download/grafana-6.59.4/grafana-6.59.4.tgz"
 
 // Step 1: Terraform
 run(`terraform -chdir=${q(terraformDir())} init -upgrade`)
@@ -38,84 +38,84 @@ helm_install("grafana-dashboards", dir("charts/grafana-dashboards"), tester, "te
 
 const localTesterName = tester["local_name"]
 helm_install("grafana", GRAFANA_CHART, tester, "tester", {
-    datasources: {
-        "datasources.yaml": {
-            apiVersion: 1,
-            datasources: [{
-                name: "mimir",
-                type: "prometheus",
-                url: "http://mimir.tester:9009/mimir/prometheus",
-                access: "proxy",
-                isDefault: true
-            }]
+  datasources: {
+    "datasources.yaml": {
+      apiVersion: 1,
+      datasources: [{
+        name: "mimir",
+        type: "prometheus",
+        url: "http://mimir.tester:9009/mimir/prometheus",
+        access: "proxy",
+        isDefault: true
+      }]
+    }
+  },
+  dashboardProviders: {
+    "dashboardproviders.yaml": {
+      apiVersion: 1,
+      providers: [{
+        name: "default",
+        folder: "",
+        type: "file",
+        disableDeletion: false,
+        editable: true,
+        options: {
+          path: "/var/lib/grafana/dashboards/default"
         }
-    },
-    dashboardProviders: {
-        "dashboardproviders.yaml": {
-            apiVersion: 1,
-            providers: [{
-                name: "default",
-                folder: "",
-                type: "file",
-                disableDeletion: false,
-                editable: true,
-                options: {
-                    path: "/var/lib/grafana/dashboards/default"
-                }
-            }]
-        }
-    },
-    dashboardsConfigMaps: { "default": "grafana-dashboards" },
-    ingress: {
-        enabled: true,
-        path: "/grafana",
-        hosts: [localTesterName]
-    },
-    env: {
-        "GF_SERVER_ROOT_URL": `http://${localTesterName}/grafana`,
-        "GF_SERVER_SERVE_FROM_SUB_PATH": "true"
-    },
-    adminPassword: ADMIN_PASSWORD,
+      }]
+    }
+  },
+  dashboardsConfigMaps: { "default": "grafana-dashboards" },
+  ingress: {
+    enabled: true,
+    path: "/grafana",
+    hosts: [localTesterName]
+  },
+  env: {
+    "GF_SERVER_ROOT_URL": `http://${localTesterName}/grafana`,
+    "GF_SERVER_SERVE_FROM_SUB_PATH": "true"
+  },
+  adminPassword: ADMIN_PASSWORD,
 })
 
 // upstream cluster
 const upstream = clusters["upstream"]
-helm_install("cert-manager", CERT_MANAGER_CHART, upstream, "cert-manager", {installCRDs: true})
+helm_install("cert-manager", CERT_MANAGER_CHART, upstream, "cert-manager", { installCRDs: true })
 
 const BOOTSTRAP_PASSWORD = "admin"
 const privateUpstreamName = upstream["private_name"]
 const privateRancherUrl = `https://${privateUpstreamName}`
 helm_install("rancher", RANCHER_CHART, upstream, "cattle-system", {
-    bootstrapPassword: BOOTSTRAP_PASSWORD,
-    hostname: privateUpstreamName,
-    replicas: isK3d() ? 1 : 3,
-    rancherImageTag: RANCHER_IMAGE_TAG,
-    extraEnv: [{
-        name: "CATTLE_SERVER_URL",
-        value: privateRancherUrl
-    },
-    {
-        name: "CATTLE_PROMETHEUS_METRICS",
-        value: "true"
-    },
-    {
-        name: "CATTLE_DEV_MODE",
-        value: "true"
-    }],
-    livenessProbe: {
-        initialDelaySeconds: 30,
-        periodSeconds: 3600
-    }
+  bootstrapPassword: BOOTSTRAP_PASSWORD,
+  hostname: privateUpstreamName,
+  replicas: isK3d() ? 1 : 3,
+  rancherImageTag: RANCHER_IMAGE_TAG,
+  extraEnv: [{
+    name: "CATTLE_SERVER_URL",
+    value: privateRancherUrl
+  },
+  {
+    name: "CATTLE_PROMETHEUS_METRICS",
+    value: "true"
+  },
+  {
+    name: "CATTLE_DEV_MODE",
+    value: "true"
+  }],
+  livenessProbe: {
+    initialDelaySeconds: 30,
+    periodSeconds: 3600
+  }
 })
 
 const localUpstreamName = upstream["local_name"]
 helm_install("rancher-ingress", dir("charts/rancher-ingress"), upstream, "default", {
-    san: localUpstreamName,
+  san: localUpstreamName,
 })
 
 const monitoringRestrictions = {
-    nodeSelector: {monitoring: "true"},
-    tolerations: [{key: "monitoring", operator: "Exists", effect: "NoSchedule"}],
+  nodeSelector: { monitoring: "true" },
+  tolerations: [{ key: "monitoring", operator: "Exists", effect: "NoSchedule" }],
 }
 
 install_rancher_monitoring(upstream, isK3d() ? {} : monitoringRestrictions, `http://${tester["private_name"]}/mimir/api/v1/push`)
@@ -129,27 +129,27 @@ run(`kubectl wait deployment/rancher --namespace cattle-system --for condition=A
 
 // Step 3: Import downstream clusters
 const localRancherUrl = `https://${localUpstreamName}:${upstream["local_https_port"]}`
-const importedClusters = Object.entries(clusters).filter(([k,v]) => k.startsWith("downstream"))
+const importedClusters = Object.entries(clusters).filter(([k, v]) => k.startsWith("downstream"))
 const importedClusterNames = importedClusters.map(([name, cluster]) => name).join(",")
-k6_run(tester, { BASE_URL: privateRancherUrl, BOOTSTRAP_PASSWORD: BOOTSTRAP_PASSWORD, PASSWORD: ADMIN_PASSWORD, IMPORTED_CLUSTER_NAMES: importedClusterNames}, {}, "k6/rancher_setup.js")
+k6_run(tester, { BASE_URL: privateRancherUrl, BOOTSTRAP_PASSWORD: BOOTSTRAP_PASSWORD, PASSWORD: ADMIN_PASSWORD, IMPORTED_CLUSTER_NAMES: importedClusterNames }, {}, "k6/rancher_setup.js")
 
 for (const [name, cluster] of importedClusters) {
-    const clusterId = await retryOnError(() =>
-        runCollectingJSONOutput(`kubectl get -n fleet-default cluster ${q(name)} -o json ${q(kuf)} ${q(cuf)}`)["status"]["clusterName"]
-    )
-    const token = runCollectingJSONOutput(`kubectl get -n ${q(clusterId)} clusterregistrationtoken.management.cattle.io default-token -o json ${q(kuf)} ${q(cuf)}`)["status"]["token"]
+  const clusterId = await retryOnError(() =>
+    runCollectingJSONOutput(`kubectl get -n fleet-default cluster ${q(name)} -o json ${q(kuf)} ${q(cuf)}`)["status"]["clusterName"]
+  )
+  const token = runCollectingJSONOutput(`kubectl get -n ${q(clusterId)} clusterregistrationtoken.management.cattle.io default-token -o json ${q(kuf)} ${q(cuf)}`)["status"]["token"]
 
-    const url = `${localRancherUrl}/v3/import/${token}_${clusterId}.yaml`
-    const yaml = runCollectingOutput(`curl --insecure -fL ${q(url)}`)
-    run(`kubectl apply -f - --kubeconfig=${q(cluster["kubeconfig"])} --context=${q(cluster["context"])}`, {input: yaml})
+  const url = `${localRancherUrl}/v3/import/${token}_${clusterId}.yaml`
+  const yaml = runCollectingOutput(`curl --insecure -fL ${q(url)}`)
+  run(`kubectl apply -f - --kubeconfig=${q(cluster["kubeconfig"])} --context=${q(cluster["context"])}`, { input: yaml })
 }
 
 run(`kubectl wait clusters.management.cattle.io --all --for condition=ready=true --timeout=1h ${q(kuf)} ${q(cuf)}`)
 
 if (importedClusters.length > 0) {
-    run(`kubectl wait cluster.fleet.cattle.io --all --namespace fleet-default --for condition=ready=true --timeout=1h ${q(kuf)} ${q(cuf)}`)
+  run(`kubectl wait cluster.fleet.cattle.io --all --namespace fleet-default --for condition=ready=true --timeout=1h ${q(kuf)} ${q(cuf)}`)
 }
 
 for (const [_, cluster] of importedClusters) {
-    install_rancher_monitoring(cluster, {})
+  install_rancher_monitoring(cluster, {})
 }

--- a/terraform/main/aws/inputs.tf
+++ b/terraform/main/aws/inputs.tf
@@ -28,7 +28,7 @@ locals {
 
 variable "project_name" {
   type    = string
-  default = "moio"
+  default = "st"
 }
 
 variable "region" {
@@ -114,7 +114,7 @@ variable "tester_cluster" {
 
 variable "num_downstreams" {
   type    = number
-  default = 0
+  default = 5
 }
 
 variable "downstream_config" {

--- a/terraform/main/aws/inputs.tf
+++ b/terraform/main/aws/inputs.tf
@@ -1,7 +1,70 @@
 locals {
-  project_name = "st"
+  project_name = var.project_name
 
-  upstream_cluster = {
+  upstream_cluster = var.upstream_cluster
+
+  downstream_clusters = var.num_downstreams > 0 ? [
+    for i in range(var.num_downstreams) :
+    merge(var.downstream_config, {
+      name       = "downstream-${i}"
+      local_name = "downstream-${i}.local.gd"
+      }
+    )
+  ] : []
+
+  tester_cluster = var.tester_cluster
+
+  clusters = concat([local.upstream_cluster], local.downstream_clusters, [local.tester_cluster])
+
+  // aws-specific
+  first_local_kubernetes_api_port = 7445
+  first_local_http_port           = 9080
+  first_local_https_port          = 9443
+  region                          = var.region
+  availability_zone               = var.availability_zone
+  ssh_private_key_path            = var.ssh_private_key_path // generate with `ssh-keygen -t ed25519`
+  ssh_public_key_path             = var.ssh_public_key_path
+}
+
+variable "project_name" {
+  type    = string
+  default = "moio"
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-2"
+}
+
+variable "availability_zone" {
+  type    = string
+  default = "us-east-2a"
+}
+
+variable "ssh_private_key_path" {
+  type = string
+}
+
+variable "ssh_public_key_path" {
+  type = string
+}
+
+variable "upstream_cluster" {
+  type = object({
+    name           = string
+    server_count   = number
+    agent_count    = number
+    distro_version = string
+    agent_labels   = optional(list(list(map(string))))
+    agent_taints   = optional(list(list(map(string))))
+
+    // aws-specific
+    local_name    = string
+    datastore     = optional(string)
+    instance_type = string
+    ami           = string
+  })
+  default = {
     name           = "upstream"
     server_count   = 3
     agent_count    = 2
@@ -18,25 +81,23 @@ locals {
     instance_type = "i3.large"
     ami           = "ami-009fd8a4732ea789b" // openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
   }
+}
 
-  downstream_clusters = [
-    for i in range(5) :
-    {
-      name           = "downstream-${i}"
-      server_count   = 3
-      agent_count    = 7
-      distro_version = "v1.24.12+k3s1"
-      agent_labels   = []
-      agent_taints   = []
+variable "tester_cluster" {
+  type = object({
+    name           = string
+    server_count   = number
+    agent_count    = number
+    distro_version = string
+    agent_labels   = optional(list(list(map(string))), [])
+    agent_taints   = optional(list(list(map(string))), [])
 
-      // aws-specific
-      local_name    = "downstream-${i}.local.gd"
-      instance_type = "t4g.large"
-      ami           = "ami-0e55a8b472a265e3f" // openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64
-    }
-  ]
-
-  tester_cluster = {
+    // aws-specific
+    local_name    = string
+    instance_type = string
+    ami           = string
+  })
+  default = {
     name           = "tester"
     server_count   = 1
     agent_count    = 0
@@ -49,24 +110,34 @@ locals {
     instance_type = "t3a.large"
     ami           = "ami-009fd8a4732ea789b" // openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
   }
-
-  clusters = concat([local.upstream_cluster], local.downstream_clusters, [local.tester_cluster])
-
-  // aws-specific
-  first_local_kubernetes_api_port = 7445
-  first_local_http_port           = 9080
-  first_local_https_port          = 9443
-  region                          = "us-east-1"
-  availability_zone               = "us-east-1a"
 }
 
-
-variable "ssh_public_key_path" {
-  description = "Path to SSH public key file (can be generated with `ssh-keygen -t ed25519`)"
-  default     = "~/.ssh/id_ed25519.pub"
+variable "num_downstreams" {
+  type    = number
+  default = 0
 }
 
-variable "ssh_private_key_path" {
-  description = "Path to SSH private key file (can be generated with `ssh-keygen -t ed25519`)"
-  default     = "~/.ssh/id_ed25519"
+variable "downstream_config" {
+  type = object({
+    name           = optional(string)
+    server_count   = number
+    agent_count    = number
+    distro_version = string
+    agent_labels   = optional(list(list(map(string))), [])
+    agent_taints   = optional(list(list(map(string))), [])
+
+    // aws-specific
+    local_name    = optional(string)
+    instance_type = string
+    ami           = string
+  })
+  default = {
+    server_count   = 3
+    agent_count    = 7
+    distro_version = "v1.24.12+k3s1"
+
+    // aws-specific
+    instance_type = "t4g.large"
+    ami           = "ami-0e55a8b472a265e3f" // openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64
+  }
 }

--- a/terraform/main/aws/main.tf
+++ b/terraform/main/aws/main.tf
@@ -1,37 +1,36 @@
 terraform {
-  required_version = "1.5.6"
+  required_version = ">= 1.3.7"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.31.0"
+      version = ">= 4.63.0, <= 5.0.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "4.0.3"
+      version = ">= 4.0.3, <= 5.0.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.7.1"
+      version = ">= 2.7.1, <= 3.0.0"
     }
     ssh = {
       source  = "loafoe/ssh"
-      version = "2.2.1"
-    }
-    k3d = {
-      source  = "pvotal-tech/k3d"
-      version = "0.0.6"
+      version = ">= 2.2.1, <= 3.0.0"
     }
   }
 }
 
 provider "aws" {
-  region = local.region
+  region  = local.region
+  profile = "rancher-eng"
 }
 
 module "network" {
   source               = "../../modules/aws_network"
   project_name         = local.project_name
   region               = local.region
+  ami                  = local.downstream_clusters[0].ami
+  instance_type        = local.downstream_clusters[0].instance_type
   availability_zone    = local.availability_zone
   ssh_public_key_path  = var.ssh_public_key_path
   ssh_private_key_path = var.ssh_private_key_path
@@ -42,6 +41,7 @@ module "cluster" {
   source         = "../../modules/aws_k3s"
   project_name   = local.project_name
   name           = local.clusters[count.index].name
+  datastore      = try(local.clusters[count.index].name == "upstream" ? local.clusters[count.index].datastore : null, null)
   server_count   = local.clusters[count.index].server_count
   agent_count    = local.clusters[count.index].agent_count
   agent_labels   = local.clusters[count.index].agent_labels
@@ -60,4 +60,5 @@ module "cluster" {
   ssh_bastion_host          = module.network.bastion_public_name
   subnet_id                 = module.network.private_subnet_id
   vpc_security_group_id     = module.network.private_security_group_id
+  depends_on                = [module.network]
 }

--- a/terraform/main/aws/main.tf
+++ b/terraform/main/aws/main.tf
@@ -1,21 +1,21 @@
 terraform {
-  required_version = ">= 1.3.7"
+  required_version = "1.5.7"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.63.0, <= 5.0.0"
+      version = "4.31.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 4.0.3, <= 5.0.0"
+      version = "4.0.3"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.7.1, <= 3.0.0"
+      version = "2.7.1"
     }
     ssh = {
       source  = "loafoe/ssh"
-      version = ">= 2.2.1, <= 3.0.0"
+      version = "2.2.1"
     }
   }
 }

--- a/terraform/main/k3d/main.tf
+++ b/terraform/main/k3d/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.5.6"
+  required_version = ">=1.3.7"
   required_providers {
     docker = {
       source  = "kreuzwerker/docker"

--- a/terraform/modules/aws_host/mount_ephemeral.sh
+++ b/terraform/modules/aws_host/mount_ephemeral.sh
@@ -3,7 +3,7 @@
 set -xe
 
 # if this host has a local SSD device (eg. m6i family), format the partition and mount it to /data
-for device in `ls /dev/nvme?n?`; do
+for device in $(ls /dev/nvme?n?); do
   if [ -b ${device} ] && [ ! -b ${device}p1 ]; then
     /usr/sbin/parted -s ${device} mklabel gpt
     /usr/sbin/parted -s ${device} mkpart primary 0% 100%

--- a/terraform/modules/aws_loadbalancer/inputs.tf
+++ b/terraform/modules/aws_loadbalancer/inputs.tf
@@ -6,7 +6,16 @@ variable "domain" {
   type = string
 }
 
+variable "vpc_id" {
+  type = string
+}
+
+variable "public_subnets" {
+  type = list(string)
+}
+
 variable "use_route53" {
-  type = bool
+  type    = bool
+  default = false
 }
 

--- a/terraform/modules/aws_loadbalancer/inputs.tf
+++ b/terraform/modules/aws_loadbalancer/inputs.tf
@@ -1,0 +1,12 @@
+variable "subdomain" {
+  type = string
+}
+
+variable "domain" {
+  type = string
+}
+
+variable "use_route53" {
+  type = bool
+}
+

--- a/terraform/modules/aws_loadbalancer/main.tf
+++ b/terraform/modules/aws_loadbalancer/main.tf
@@ -1,0 +1,91 @@
+resource "aws_lb" "public-lb" {
+  name               = "${var.subdomain}-public-lb"
+  internal           = false
+  load_balancer_type = "network"
+  subnets            = var.public_subnets
+}
+
+resource "aws_lb_target_group" "server-443" {
+  name     = "${var.subdomain}-443"
+  port     = 443
+  protocol = "TCP"
+  vpc_id   = var.vpc_id
+
+  health_check {
+    interval            = 10
+    timeout             = 6
+    path                = "/healthz"
+    port                = 80
+    protocol            = "HTTP"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = ""
+  }
+
+  stickiness {
+    type    = "source_ip"
+    enabled = false
+  }
+}
+
+resource "aws_lb_target_group" "server-80" {
+  name     = "${var.subdomain}-80"
+  port     = 80
+  protocol = "TCP"
+  vpc_id   = var.vpc_id
+
+  health_check {
+    interval            = 10
+    timeout             = 6
+    path                = "/healthz"
+    port                = 80
+    protocol            = "HTTP"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200-399"
+  }
+
+  stickiness {
+    type    = "source_ip"
+    enabled = false
+  }
+}
+
+resource "aws_lb_listener" "server-port_443" {
+  load_balancer_arn = aws_lb.public-lb.arn
+  port              = "443"
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.server-443.arn
+  }
+}
+
+resource "aws_lb_listener" "server-port_80" {
+  load_balancer_arn = aws_lb.public-lb.arn
+  port              = "80"
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.server-80.arn
+  }
+}
+
+#############################
+### Create Public Rancher DNS
+#############################
+data "aws_route53_zone" "dns_zone" {
+  count = var.use_route53 ? 1 : 0
+  name  = var.domain
+}
+
+resource "aws_route53_record" "public" {
+  count   = var.use_route53 ? 1 : 0
+  zone_id = data.aws_route53_zone.dns_zone.0.zone_id
+  name    = "${var.subdomain}.${var.domain}"
+  type    = "CNAME"
+  ttl     = 30
+  records = [aws_lb.public-lb.dns_name]
+}

--- a/terraform/modules/aws_loadbalancer/outputs.tf
+++ b/terraform/modules/aws_loadbalancer/outputs.tf
@@ -1,0 +1,7 @@
+output "dns_name" {
+  value = aws_lb.public-lb.dns_name
+}
+
+output "arn" {
+  value = aws_lb.public-lb.arn
+}

--- a/terraform/modules/aws_network/inputs.tf
+++ b/terraform/modules/aws_network/inputs.tf
@@ -8,6 +8,18 @@ variable "region" {
   type        = string
 }
 
+variable "ami" {
+  description = "Optional AMI to use for bastion host. Will use the default from `aws_host` module if not set"
+  type        = string
+  default     = null
+}
+
+variable "instance_type" {
+  description = "Optional instance_type to use for bastion host. Will use the default from `aws_host` module if not set"
+  type        = string
+  default     = null
+}
+
 variable "availability_zone" {
   description = "Availability zone where the instance is created"
   type        = string


### PR DESCRIPTION
The changes can be summarized as follows:

- ignore tfvars in VCS
- add input vars for ami and instance_types
- add options to upstream and downstream cluster objects
   - refactor of downstream_clusters local var 
   - added optional datastore field
- add more specific version constraints to tf providers
- default to rancher-eng aws profile for aws tf provider auth