### PR TITLE
RKE1 fixes

### DIFF
--- a/terraform/modules/aws_rke/inputs.tf
+++ b/terraform/modules/aws_rke/inputs.tf
@@ -81,7 +81,7 @@ variable "sans" {
 
 variable "distro_version" {
   description = "RKE version followed by the Kubernetes version, see https://github.com/rancher/rke/releases"
-  default     = "v1.3.15/rke_darwin-amd64 v1.23.10-rancher1-1"
+  default     = "v1.4.10/rke_darwin-amd64 v1.26.8-rancher1-1"
 }
 
 variable "max_pods" {

--- a/terraform/modules/rke/main.tf
+++ b/terraform/modules/rke/main.tf
@@ -38,6 +38,15 @@ resource "local_file" "rke_config" {
   })
 
   filename = "${path.module}/../../../config/rke_config/${var.name}.yaml"
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "rm -f ${replace(self.filename, "/^(.+).yaml$/", "$1.rkestate")}"
+  }
+  provisioner "local-exec" {
+    when    = destroy
+    command = "rm -f ${replace(self.filename, "/^(.+)/(.+?).yaml$/", "$1/kube_config_$2.yaml")}"
+  }
 }
 
 resource "null_resource" "rke_up_execution" {

--- a/terraform/modules/rke/prepare_for_rke.sh
+++ b/terraform/modules/rke/prepare_for_rke.sh
@@ -10,8 +10,7 @@ fi
 
 # https://rancher.com/docs/rke/latest/en/os/#suse-linux-enterprise-server-sles-opensuse
 if grep --quiet --ignore-case suse < /etc/os-release; then
-  zypper addrepo https://download.docker.com/linux/centos/docker-ce.repo
-  zypper install -y docker-ce
+  zypper install -y docker
 fi
 
 # https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository


### PR DESCRIPTION
1. bump the RKE version to most current one supported by Rancher
2. clean up RKE state files on destroy. Previously, recreating a cluster after having destroying it resulted in errors as RKE tried to 'upgrade' it
3. use distro's Docker on green distros, as Docker Inc does not publish builds for them

@git-ival @fgiudici I am adding you as reviewers mostly FYI and to give an occasion to object if you see anything strange. I did test them and work fine here, you do not really have to re-test them.