### PR TITLE
AWS fixes

### DIFF
--- a/terraform/modules/aws_network/inputs.tf
+++ b/terraform/modules/aws_network/inputs.tf
@@ -28,3 +28,14 @@ variable "ssh_private_key_path" {
   description = "Path of private ssh key for AWS"
   type        = string
 }
+
+variable "bastion_host_ami" {
+  description = "AMI ID"
+  default     = "ami-0e55a8b472a265e3f"
+  // openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64-a516e959-df54-4035-bb1a-63599b7a6df9
+}
+
+variable "bastion_host_instance_type" {
+  description = "EC2 instance type"
+  default     = "t4g.small"
+}

--- a/terraform/modules/aws_network/main.tf
+++ b/terraform/modules/aws_network/main.tf
@@ -232,6 +232,8 @@ module "bastion" {
   availability_zone     = var.availability_zone
   project_name          = var.project_name
   name                  = "bastion"
+  ami                   = var.bastion_host_ami
+  instance_type         = var.bastion_host_instance_type
   ssh_key_name          = aws_key_pair.key_pair.key_name
   ssh_private_key_path  = var.ssh_private_key_path
   subnet_id             = aws_subnet.public.id

--- a/terraform/modules/aws_network/main.tf
+++ b/terraform/modules/aws_network/main.tf
@@ -31,7 +31,6 @@ locals {
 }
 
 resource "aws_eip" "nat_eip" {
-  vpc  = true
   tags = {
     Project = var.project_name
     Name    = "${var.project_name}-nat-eip"
@@ -164,9 +163,9 @@ resource "aws_security_group" "public" {
   }
 
   ingress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
     cidr_blocks = concat([aws_subnet.private.cidr_block], var.secondary_availability_zone != null ? [
       aws_subnet.secondary_private[0].cidr_block
     ] : [])


### PR DESCRIPTION
1. drops an option which was ineffective/useless, moreover it was also deprecated
2. adds the ability to change the bastion host AMI (necessary to use in different regions) and type (for good measure)

@git-ival @fgiudici I am adding you as reviewers mostly FYI and to give an occasion to object if you see anything strange. I did test them and work fine here, you do not really have to re-test them.

@git-ival you had those in a similar form in your PR, but I needed them separately elsewhere, so I isolated the commits in their own PR. I did add you as `Co-authored-by` to give proper credit, thanks!