### PR TITLE
AWS: allow to mix distros

### DIFF
--- a/terraform/main/aws/outputs.tf
+++ b/terraform/main/aws/outputs.tf
@@ -1,13 +1,39 @@
-output "clusters" {
-  value = {
-    for i, cluster in local.clusters : cluster.name => {
-      local_name           = cluster.local_name,
-      local_http_port      = module.cluster[i].local_http_port
-      local_https_port     = module.cluster[i].local_https_port
-      private_name         = module.cluster[i].first_server_private_name
-      kubeconfig           = module.cluster[i].kubeconfig
-      context              = module.cluster[i].context
-      node_access_commands = module.cluster[i].node_access_commands
+locals {
+  k3s_outputs = { for i, cluster in local.k3s_clusters : cluster.name => {
+    local_name           = cluster.local_name,
+    local_http_port      = module.k3s_cluster[i].local_http_port
+    local_https_port     = module.k3s_cluster[i].local_https_port
+    private_name         = module.k3s_cluster[i].first_server_private_name
+    public_name          = module.k3s_cluster[i].first_server_public_name
+    kubeconfig           = module.k3s_cluster[i].kubeconfig
+    context              = module.k3s_cluster[i].context
+    node_access_commands = module.k3s_cluster[i].node_access_commands
     }
   }
+  rke_outputs = { for i, cluster in local.rke_clusters : cluster.name => {
+    local_name           = cluster.local_name,
+    local_http_port      = module.rke_cluster[i].local_http_port
+    local_https_port     = module.rke_cluster[i].local_https_port
+    private_name         = module.rke_cluster[i].first_server_private_name
+    public_name          = module.rke_cluster[i].first_server_public_name
+    kubeconfig           = module.rke_cluster[i].kubeconfig
+    context              = module.rke_cluster[i].context
+    node_access_commands = module.rke_cluster[i].node_access_commands
+    }
+  }
+  rke2_outputs = { for i, cluster in local.rke2_clusters : cluster.name => {
+    local_name           = cluster.local_name,
+    local_http_port      = module.rke2_cluster[i].local_http_port
+    local_https_port     = module.rke2_cluster[i].local_https_port
+    private_name         = module.rke2_cluster[i].first_server_private_name
+    public_name          = module.rke2_cluster[i].first_server_public_name
+    kubeconfig           = module.rke2_cluster[i].kubeconfig
+    context              = module.rke2_cluster[i].context
+    node_access_commands = module.rke2_cluster[i].node_access_commands
+    }
+  }
+}
+
+output "clusters" {
+  value = merge(local.k3s_outputs, local.rke_outputs, local.rke2_outputs)
 }

--- a/terraform/modules/aws_rke/inputs.tf
+++ b/terraform/modules/aws_rke/inputs.tf
@@ -23,6 +23,18 @@ variable "agent_count" {
   default     = 0
 }
 
+variable "agent_labels" {
+  description = "Per-agent-node lists of labels to apply"
+  type        = list(list(object({ key : string, value : string })))
+  default     = []
+}
+
+variable "agent_taints" {
+  description = "Per-agent-node lists of taints to apply"
+  type        = list(list(object({ key : string, value : string, effect : string })))
+  default     = []
+}
+
 variable "ami" {
   description = "AMI ID for all nodes in this cluster"
   type        = string

--- a/terraform/modules/aws_rke/main.tf
+++ b/terraform/modules/aws_rke/main.tf
@@ -11,7 +11,7 @@ module "server_nodes" {
   subnet_id             = var.subnet_id
   vpc_security_group_id = var.vpc_security_group_id
   ssh_bastion_host      = var.ssh_bastion_host
-  ssh_tunnels           = count.index == 0 ? [
+  ssh_tunnels = count.index == 0 ? [
     [var.local_kubernetes_api_port, 6443],
     [var.local_http_port, 80],
     [var.local_https_port, 443],
@@ -41,6 +41,8 @@ module "rke" {
   name         = var.name
   server_names = [for node in module.server_nodes : node.private_name]
   agent_names  = [for node in module.agent_nodes : node.private_name]
+  agent_labels = var.agent_labels
+  agent_taints = var.agent_taints
   sans         = var.sans
 
   ssh_private_key_path      = var.ssh_private_key_path

--- a/terraform/modules/aws_rke/outputs.tf
+++ b/terraform/modules/aws_rke/outputs.tf
@@ -18,10 +18,10 @@ output "local_https_port" {
   value = var.local_https_port
 }
 
-output "ssh_scripts" {
+output "node_access_commands" {
   value = merge({
-  for node in module.server_nodes : node.name => { ssh_script : node.ssh_script_filename }
-  }, {
-  for node in module.agent_nodes : node.name => { ssh_script : node.ssh_script_filename }
+    for node in module.server_nodes : node.name => node.ssh_script_filename
+    }, {
+    for node in module.agent_nodes : node.name => node.ssh_script_filename
   })
 }

--- a/terraform/modules/aws_rke2/inputs.tf
+++ b/terraform/modules/aws_rke2/inputs.tf
@@ -23,6 +23,18 @@ variable "agent_count" {
   default     = 0
 }
 
+variable "agent_labels" {
+  description = "Per-agent-node lists of labels to apply"
+  type        = list(list(object({ key : string, value : string })))
+  default     = []
+}
+
+variable "agent_taints" {
+  description = "Per-agent-node lists of taints to apply"
+  type        = list(list(object({ key : string, value : string, effect : string })))
+  default     = []
+}
+
 variable "ami" {
   description = "AMI ID for all nodes in this cluster"
   type        = string

--- a/terraform/modules/aws_rke2/main.tf
+++ b/terraform/modules/aws_rke2/main.tf
@@ -41,6 +41,8 @@ module "rke2" {
   name         = var.name
   server_names = [for node in module.server_nodes : node.private_name]
   agent_names  = [for node in module.agent_nodes : node.private_name]
+  agent_labels = var.agent_labels
+  agent_taints = var.agent_taints
   sans         = var.sans
 
   ssh_private_key_path      = var.ssh_private_key_path

--- a/terraform/modules/rke/cluster.yaml
+++ b/terraform/modules/rke/cluster.yaml
@@ -14,12 +14,26 @@ nodes:
     - etcd
     - worker
 %{ endfor ~}
-%{ for agent_name in agent_names ~}
+%{ for i, agent_name in agent_names ~}
 - address: ${jsonencode(agent_name)}
   user: root
   role:
     - worker
-%{ endfor }
+%{ if length(agent_labels) > i && length(agent_labels[i]) > 0 ~}
+  labels:
+%{ for label in agent_labels[i] ~}
+    - ${label.key}=${label.value}
+%{ endfor ~}
+%{endif ~}
+%{ if length(agent_taints) > i && length(agent_taints[i]) > 0 ~}
+  taints:
+%{ for taint in agent_taints[i] ~}
+    - key: ${taint.key}
+      value: ${taint.value}
+      effect: ${taint.effect}
+%{ endfor ~}
+%{endif ~}
+%{ endfor ~}
 
 # Service-specific settings
 services:

--- a/terraform/modules/rke/inputs.tf
+++ b/terraform/modules/rke/inputs.tf
@@ -24,6 +24,18 @@ variable "agent_names" {
   default     = []
 }
 
+variable "agent_labels" {
+  description = "Per-agent-node lists of labels to apply"
+  type        = list(list(object({ key : string, value : string })))
+  default     = []
+}
+
+variable "agent_taints" {
+  description = "Per-agent-node lists of taints to apply"
+  type        = list(list(object({ key : string, value : string, effect : string })))
+  default     = []
+}
+
 variable "sans" {
   description = "Additional Subject Alternative Names"
   type        = list(string)

--- a/terraform/modules/rke/main.tf
+++ b/terraform/modules/rke/main.tf
@@ -35,6 +35,8 @@ resource "local_file" "rke_config" {
     max_pods             = var.max_pods
     node_cidr_mask_size  = var.node_cidr_mask_size
     sans                 = var.sans
+    agent_labels         = var.agent_labels
+    agent_taints         = var.agent_taints
   })
 
   filename = "${path.module}/../../../config/rke_config/${var.name}.yaml"
@@ -46,7 +48,7 @@ resource "null_resource" "rke_up_execution" {
 
   provisioner "local-exec" {
     interpreter = ["bash", "-c"]
-    command     = templatefile("${path.module}/download_rke.sh", {
+    command = templatefile("${path.module}/download_rke.sh", {
       version = split(" ", var.distro_version)[0]
       target  = "${path.module}/../../../config"
     })

--- a/terraform/modules/rke/outputs.tf
+++ b/terraform/modules/rke/outputs.tf
@@ -45,7 +45,7 @@ resource "local_file" "kubeconfig" {
 }
 
 output "kubeconfig" {
-  value = abspath(local_file.kubeconfig.filename)
+  value = length(var.server_names) > 0 ? abspath(local_file.kubeconfig[0].filename) : null
 }
 
 output "context" {

--- a/terraform/modules/rke2/inputs.tf
+++ b/terraform/modules/rke2/inputs.tf
@@ -24,6 +24,18 @@ variable "agent_names" {
   default     = []
 }
 
+variable "agent_labels" {
+  description = "Per-agent-node lists of labels to apply"
+  type        = list(list(object({ key : string, value : string })))
+  default     = []
+}
+
+variable "agent_taints" {
+  description = "Per-agent-node lists of taints to apply"
+  type        = list(list(object({ key : string, value : string, effect : string })))
+  default     = []
+}
+
 variable "sans" {
   description = "Additional Subject Alternative Names"
   type        = list(string)

--- a/terraform/modules/rke2/install_rke2.sh
+++ b/terraform/modules/rke2/install_rke2.sh
@@ -45,6 +45,12 @@ mkdir -p /etc/rancher/rke2/
 cat >/etc/rancher/rke2/config.yaml <<EOF
 server: ${jsonencode(server_url)}
 token: ${jsonencode(token)}
+%{ for label in labels ~}
+node-label: ${label.key}=${label.value}
+%{ endfor ~}
+%{ for taint in taints ~}
+node-taint: ${taint.key}=${taint.value}:${taint.effect}
+%{ endfor ~}
 tls-san:
 %{ for san in sans ~}
   - ${jsonencode(san)}

--- a/terraform/modules/rke2/main.tf
+++ b/terraform/modules/rke2/main.tf
@@ -99,10 +99,12 @@ resource "ssh_resource" "agent_installation" {
   file {
     content = templatefile("${path.module}/install_rke2.sh", {
       distro_version = var.distro_version,
-      sans         = [var.agent_names[count.index]]
-      type         = "agent"
-      token        = ssh_sensitive_resource.first_server_installation[0].result
-      server_url   = "https://${var.server_names[0]}:9345"
+      sans           = [var.agent_names[count.index]]
+      type           = "agent"
+      token          = ssh_sensitive_resource.first_server_installation[0].result
+      server_url     = "https://${var.server_names[0]}:9345"
+      labels         = length(var.agent_labels) > count.index ? var.agent_labels[count.index] : []
+      taints         = length(var.agent_taints) > count.index ? var.agent_taints[count.index] : []
 
       client_ca_key          = tls_private_key.client_ca_key.private_key_pem
       client_ca_cert         = tls_self_signed_cert.client_ca_cert.cert_pem


### PR DESCRIPTION
Adds the ability of using different distros for upstream/downstream/tester clusters in AWS (all other backends only support k3s at this point).

Prerequisite commits uniform inputs and outputs of RKE/RKE2 with the k3s equivalents, so that all work in the same way. Code is a little bit tedious but at least it's straightforward.

@git-ival @fgiudici I am adding you as reviewers mostly FYI and to give an occasion to object if you see anything strange. I did test them and work fine here, you do not really have to re-test them.

@fgiudici this is relevant for your work on the Azure backend. I do not think impact should be major, but let me know if you have any questions.