### PR TITLE
AWS: allow exposing cluster nodes

### DIFF
--- a/bin/run_tests.mjs
+++ b/bin/run_tests.mjs
@@ -52,7 +52,12 @@ console.log("*** ACCESS DETAILS")
 console.log()
 
 console.log(`*** UPSTREAM CLUSTER`)
-console.log(`    Rancher UI: https://${upstream["local_name"]}:${upstream["local_https_port"]} (admin/${ADMIN_PASSWORD})`)
+if (upstream["public_name"]) {
+    console.log(`    Rancher UI: https://${upstream["public_name"]} (admin/${ADMIN_PASSWORD})`)
+}
+else {
+    console.log(`    Rancher UI: https://${upstream["local_name"]}:${upstream["local_https_port"]} (admin/${ADMIN_PASSWORD})`)
+}
 console.log(`    Kubernetes API:`)
 console.log(`export KUBECONFIG=${q(upstream["kubeconfig"])}`)
 console.log(`kubectl config use-context ${q(upstream["context"])}`)

--- a/bin/setup.mjs
+++ b/bin/setup.mjs
@@ -109,8 +109,9 @@ helm_install("rancher", RANCHER_CHART, upstream, "cattle-system", {
 })
 
 const localUpstreamName = upstream["local_name"]
+const publicUpstreamName = upstream["public_name"]
 helm_install("rancher-ingress", dir("charts/rancher-ingress"), upstream, "default", {
-    san: localUpstreamName,
+    sans: [localUpstreamName, privateUpstreamName, publicUpstreamName].filter(x => x),
 })
 
 const monitoringRestrictions = {

--- a/charts/rancher-ingress/templates/ingress.yaml
+++ b/charts/rancher-ingress/templates/ingress.yaml
@@ -7,16 +7,20 @@ metadata:
    namespace: cattle-system
 spec:
  rules:
- - host: {{ $.Values.san }}
-   http:
-     paths:
-     - backend:
-         service:
-           name: rancher
-           port:
-             number: 80
-       pathType: ImplementationSpecific
+{{- range .Values.sans }}
+   - host: {{ . }}
+     http:
+       paths:
+       - backend:
+           service:
+             name: rancher
+             port:
+               number: 80
+         pathType: ImplementationSpecific
+{{- end }}
  tls:
  - hosts:
-   - {{ $.Values.san }}
+{{- range .Values.sans }}
+   - {{ . }}
+{{- end }}
    secretName: tls-rancher-ingress

--- a/charts/rancher-ingress/values.yaml
+++ b/charts/rancher-ingress/values.yaml
@@ -2,4 +2,5 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-san: rancher.local.gd
+sans:
+  - rancher.local.gd

--- a/terraform/main/aws/inputs.tf
+++ b/terraform/main/aws/inputs.tf
@@ -15,6 +15,7 @@ locals {
 
     // aws-specific
     local_name    = "upstream.local.gd"
+    public_ip     = true
     instance_type = "i3.large"
     ami           = "ami-009fd8a4732ea789b" // openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
   }
@@ -31,6 +32,7 @@ locals {
 
       // aws-specific
       local_name    = "downstream-${i}.local.gd"
+      public_ip     = false
       instance_type = "t4g.large"
       ami           = "ami-0e55a8b472a265e3f" // openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64
     }
@@ -46,6 +48,7 @@ locals {
 
     // aws-specific
     local_name    = "tester.local.gd"
+    public_ip     = false
     instance_type = "t3a.large"
     ami           = "ami-009fd8a4732ea789b" // openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
   }

--- a/terraform/main/aws/main.tf
+++ b/terraform/main/aws/main.tf
@@ -64,8 +64,8 @@ module "k3s_cluster" {
   ssh_key_name              = module.network.key_name
   ssh_private_key_path      = var.ssh_private_key_path
   ssh_bastion_host          = module.network.bastion_public_name
-  subnet_id                 = module.network.private_subnet_id
-  vpc_security_group_id     = module.network.private_security_group_id
+  subnet_id                 = local.k3s_clusters[count.index].public_ip ? module.network.public_subnet_id : module.network.private_subnet_id
+  vpc_security_group_id     = local.k3s_clusters[count.index].public_ip ? module.network.public_security_group_id : module.network.private_security_group_id
 }
 
 module "rke_cluster" {
@@ -89,8 +89,8 @@ module "rke_cluster" {
   ssh_key_name              = module.network.key_name
   ssh_private_key_path      = var.ssh_private_key_path
   ssh_bastion_host          = module.network.bastion_public_name
-  subnet_id                 = module.network.private_subnet_id
-  vpc_security_group_id     = module.network.private_security_group_id
+  subnet_id                 = local.rke_clusters[count.index].public_ip ? module.network.public_subnet_id : module.network.private_subnet_id
+  vpc_security_group_id     = local.rke_clusters[count.index].public_ip ? module.network.public_security_group_id : module.network.private_security_group_id
 }
 
 module "rke2_cluster" {
@@ -114,6 +114,6 @@ module "rke2_cluster" {
   ssh_key_name              = module.network.key_name
   ssh_private_key_path      = var.ssh_private_key_path
   ssh_bastion_host          = module.network.bastion_public_name
-  subnet_id                 = module.network.private_subnet_id
-  vpc_security_group_id     = module.network.private_security_group_id
+  subnet_id                 = local.rke2_clusters[count.index].public_ip ? module.network.public_subnet_id : module.network.private_subnet_id
+  vpc_security_group_id     = local.rke2_clusters[count.index].public_ip ? module.network.public_security_group_id : module.network.private_security_group_id
 }

--- a/terraform/modules/aws_host/main.tf
+++ b/terraform/modules/aws_host/main.tf
@@ -22,7 +22,7 @@ resource "null_resource" "host_configuration" {
   depends_on = [aws_instance.instance]
 
   connection {
-    host        = coalesce(aws_instance.instance.public_dns, aws_instance.instance.private_dns)
+    host        = var.ssh_bastion_host == null ? aws_instance.instance.public_dns : aws_instance.instance.private_dns
     private_key = file(var.ssh_private_key_path)
     user        = "root"
 
@@ -46,7 +46,7 @@ resource "null_resource" "host_configuration" {
 }
 
 resource "local_file" "open_tunnels" {
-  count   = length(var.ssh_tunnels) > 0 ? 1 : 0
+  count = length(var.ssh_tunnels) > 0 ? 1 : 0
   content = templatefile("${path.module}/open-tunnels-to.sh", {
     ssh_bastion_host = var.ssh_bastion_host,
     ssh_tunnels      = var.ssh_tunnels,

--- a/terraform/modules/aws_k3s/main.tf
+++ b/terraform/modules/aws_k3s/main.tf
@@ -11,7 +11,7 @@ module "server_nodes" {
   subnet_id             = var.subnet_id
   vpc_security_group_id = var.vpc_security_group_id
   ssh_bastion_host      = var.ssh_bastion_host
-  ssh_tunnels           = count.index == 0 ? [
+  ssh_tunnels = count.index == 0 ? [
     [var.local_kubernetes_api_port, 6443],
     [var.local_http_port, 80],
     [var.local_https_port, 443],
@@ -55,7 +55,7 @@ module "k3s" {
   agent_names  = [for node in module.agent_nodes : node.private_name]
   agent_labels = var.agent_labels
   agent_taints = var.agent_taints
-  sans         = length(var.sans) > 0 ? var.sans : (var.server_count > 0 ? [module.server_nodes[0].private_name] : [])
+  sans         = compact(concat(var.sans, var.server_count > 0 ? [module.server_nodes[0].private_name, module.server_nodes[0].public_name] : []))
 
   ssh_private_key_path      = var.ssh_private_key_path
   ssh_bastion_host          = var.ssh_bastion_host
@@ -64,13 +64,13 @@ module "k3s" {
   distro_version      = var.distro_version
   max_pods            = var.max_pods
   node_cidr_mask_size = var.node_cidr_mask_size
-  datastore_endpoint  = (
-  var.datastore_endpoint != null ?
-  var.datastore_endpoint :
-  var.datastore == "mariadb" ?
-  "mysql://${module.rds[0].username}:${module.rds[0].password}@tcp(${module.rds[0].endpoint})/${module.rds[0].db_name}" :
-  var.datastore == "postgres" ?
-  "postgres://${module.rds[0].username}:${module.rds[0].password}@${module.rds[0].endpoint}/${module.rds[0].db_name}" :
-  null
+  datastore_endpoint = (
+    var.datastore_endpoint != null ?
+    var.datastore_endpoint :
+    var.datastore == "mariadb" ?
+    "mysql://${module.rds[0].username}:${module.rds[0].password}@tcp(${module.rds[0].endpoint})/${module.rds[0].db_name}" :
+    var.datastore == "postgres" ?
+    "postgres://${module.rds[0].username}:${module.rds[0].password}@${module.rds[0].endpoint}/${module.rds[0].db_name}" :
+    null
   )
 }

--- a/terraform/modules/aws_k3s/outputs.tf
+++ b/terraform/modules/aws_k3s/outputs.tf
@@ -2,6 +2,10 @@ output "first_server_private_name" {
   value = var.server_count > 0 ? module.server_nodes[0].private_name : null
 }
 
+output "first_server_public_name" {
+  value = var.server_count > 0 ? module.server_nodes[0].public_name : null
+}
+
 output "kubeconfig" {
   value = module.k3s.kubeconfig
 }

--- a/terraform/modules/aws_network/main.tf
+++ b/terraform/modules/aws_network/main.tf
@@ -152,7 +152,7 @@ resource "aws_vpc_dhcp_options_association" "vpc_dhcp_options" {
 
 resource "aws_security_group" "public" {
   name        = "${var.project_name}-public-security-group"
-  description = "Allow inbound connections from the private subnet; allow connections on ports 22 (SSH); allow all outbound connections"
+  description = "Allow inbound connections from the VPC; allow connections on ports 22 (SSH) and 443 (HTTPS); allow all outbound connections"
   vpc_id      = local.vpc_id
 
   ingress {
@@ -163,12 +163,17 @@ resource "aws_security_group" "public" {
   }
 
   ingress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-    cidr_blocks = concat([aws_subnet.private.cidr_block], var.secondary_availability_zone != null ? [
-      aws_subnet.secondary_private[0].cidr_block
-    ] : [])
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [local.vpc_cidr_block]
   }
 
   egress {

--- a/terraform/modules/aws_rke/main.tf
+++ b/terraform/modules/aws_rke/main.tf
@@ -43,7 +43,7 @@ module "rke" {
   agent_names  = [for node in module.agent_nodes : node.private_name]
   agent_labels = var.agent_labels
   agent_taints = var.agent_taints
-  sans         = var.sans
+  sans         = compact(concat(var.sans, var.server_count > 0 ? [module.server_nodes[0].private_name, module.server_nodes[0].public_name] : []))
 
   ssh_private_key_path      = var.ssh_private_key_path
   ssh_bastion_host          = var.ssh_bastion_host

--- a/terraform/modules/aws_rke/outputs.tf
+++ b/terraform/modules/aws_rke/outputs.tf
@@ -2,6 +2,10 @@ output "first_server_private_name" {
   value = var.server_count > 0 ? module.server_nodes[0].private_name : null
 }
 
+output "first_server_public_name" {
+  value = var.server_count > 0 ? module.server_nodes[0].public_name : null
+}
+
 output "kubeconfig" {
   value = module.rke.kubeconfig
 }

--- a/terraform/modules/aws_rke2/main.tf
+++ b/terraform/modules/aws_rke2/main.tf
@@ -11,7 +11,7 @@ module "server_nodes" {
   subnet_id             = var.subnet_id
   vpc_security_group_id = var.vpc_security_group_id
   ssh_bastion_host      = var.ssh_bastion_host
-  ssh_tunnels           = count.index == 0 ? [
+  ssh_tunnels = count.index == 0 ? [
     [var.local_kubernetes_api_port, 6443],
     [var.local_http_port, 80],
     [var.local_https_port, 443],

--- a/terraform/modules/aws_rke2/outputs.tf
+++ b/terraform/modules/aws_rke2/outputs.tf
@@ -2,6 +2,10 @@ output "first_server_private_name" {
   value = var.server_count > 0 ? module.server_nodes[0].private_name : null
 }
 
+output "first_server_public_name" {
+  value = var.server_count > 0 ? module.server_nodes[0].public_name : null
+}
+
 output "kubeconfig" {
   value = module.rke2.kubeconfig
 }
@@ -20,8 +24,8 @@ output "local_https_port" {
 
 output "ssh_scripts" {
   value = merge({
-  for node in module.server_nodes : node.name => { ssh_script : node.ssh_script_filename }
-  }, {
-  for node in module.agent_nodes : node.name => { ssh_script : node.ssh_script_filename }
+    for node in module.server_nodes : node.name => { ssh_script : node.ssh_script_filename }
+    }, {
+    for node in module.agent_nodes : node.name => { ssh_script : node.ssh_script_filename }
   })
 }

--- a/terraform/modules/k3d_k3s/outputs.tf
+++ b/terraform/modules/k3d_k3s/outputs.tf
@@ -50,6 +50,10 @@ output "first_server_private_name" {
   value = "k3d-${var.project_name}-${var.name}-server-0"
 }
 
+output "first_server_public_name" {
+  value = null
+}
+
 output "local_http_port" {
   value = var.local_http_port
 }

--- a/terraform/modules/openstack_k3s/outputs.tf
+++ b/terraform/modules/openstack_k3s/outputs.tf
@@ -2,6 +2,10 @@ output "first_server_private_name" {
   value = var.server_count > 0 ? module.server_nodes[0].public_name : null
 }
 
+output "first_server_public_name" {
+  value = var.server_count > 0 ? module.server_nodes[0].public_name : null
+}
+
 output "kubeconfig" {
   value = module.k3s.kubeconfig
 }

--- a/terraform/modules/rke/outputs.tf
+++ b/terraform/modules/rke/outputs.tf
@@ -14,19 +14,19 @@ resource "local_file" "kubeconfig" {
           certificate-authority-data = yamldecode(data.local_file.rke_kubeconfig[0].content)["clusters"][0]["cluster"]["certificate-authority-data"]
           server                     = "https://${var.sans[0]}:${var.local_kubernetes_api_port}"
         }
-        name = var.sans[0]
+        name = var.name
       }
     ]
     contexts = [
       {
         context = {
-          cluster = var.sans[0]
+          cluster = var.name
           user : "kube-admin-local"
         }
-        name = var.sans[0]
+        name = var.name
       }
     ]
-    current-context = var.sans[0]
+    current-context = var.name
     kind            = "Config"
     preferences     = {}
     users = [

--- a/terraform/modules/rke2/main.tf
+++ b/terraform/modules/rke2/main.tf
@@ -17,10 +17,12 @@ resource "ssh_sensitive_resource" "first_server_installation" {
   file {
     content = templatefile("${path.module}/install_rke2.sh", {
       distro_version = var.distro_version,
-      sans         = concat([var.server_names[0]], var.sans)
-      type         = "server"
-      token        = null
-      server_url   = null
+      sans           = concat([var.server_names[0]], var.sans)
+      type           = "server"
+      token          = null
+      server_url     = null
+      labels         = []
+      taints         = []
 
       client_ca_key          = tls_private_key.client_ca_key.private_key_pem
       client_ca_cert         = tls_self_signed_cert.client_ca_cert.cert_pem
@@ -62,10 +64,12 @@ resource "ssh_resource" "additional_server_installation" {
   file {
     content = templatefile("${path.module}/install_rke2.sh", {
       distro_version = var.distro_version,
-      sans         = [var.server_names[count.index + 1]]
-      type         = "server"
-      token        = ssh_sensitive_resource.first_server_installation[0].result
-      server_url   = "https://${var.server_names[0]}:9345"
+      sans           = [var.server_names[count.index + 1]]
+      type           = "server"
+      token          = ssh_sensitive_resource.first_server_installation[0].result
+      server_url     = "https://${var.server_names[0]}:9345"
+      labels         = []
+      taints         = []
 
       client_ca_key          = tls_private_key.client_ca_key.private_key_pem
       client_ca_cert         = tls_self_signed_cert.client_ca_cert.cert_pem


### PR DESCRIPTION
AWS: this allows to optionally publish ports 80, 443 and 22 of cluster nodes via public IPs (not elastic, as this is meant for temporary environments only).

The reason is being able to test integration with public services such as AzureAD authentication.

This is simpler than using a load balancer, as it relies on Kubernetes' NodePort functionality to do the routing without needing a proper AWS Load Balancer.

Note that while this is perfectly OK for many test use cases, proper deployments in production should use Ingresses and Load Balancers deployed by Kubernetes.

This PR depends on #16, therefore it contains its commits. The only one to really review is  f2953fde4293d6b4440f3277ee29a18826901daf

@git-ival @fgiudici I am adding you as reviewers mostly FYI and to give an occasion to object if you see anything strange. I did test them and work fine here, you do not really have to re-test them.

@git-ival this is an alternative to the AWS LB you proposed in #13. Because of the above, I currently consider this a functional replacement.

@fgiudici this should not really have any impact on the Azure work you are doing except perhaps giving some extra inspiration - I am fairly sure the networking mechanisms/configuration will be different.