### PR TITLE
aws_host/minor: drop duplicate provisioner

### DIFF
--- a/terraform/modules/aws_host/main.tf
+++ b/terraform/modules/aws_host/main.tf
@@ -39,10 +39,6 @@ resource "null_resource" "host_configuration" {
   provisioner "remote-exec" {
     inline = var.host_configuration_commands
   }
-
-  provisioner "remote-exec" {
-    inline = var.host_configuration_commands
-  }
 }
 
 resource "local_file" "open_tunnels" {


### PR DESCRIPTION
Spotted duplicate provisioner....  anyway wondering if it is a code refactor leftover or if it is there by purpose 🤔 