### PR TITLE
Move config files into respective main dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,7 @@ terraform/main/*/.terraform
 terraform/main/*/.terraform.lock.hcl
 terraform/main/*/terraform.tfstate
 terraform/main/*/terraform.tfstate.*
-config/*.yaml
-config/*.sh
-config/rke*
+terraform/main/*/config
 
 bin/out.json
 bin/results.csv

--- a/terraform/modules/k3d_k3s/outputs.tf
+++ b/terraform/modules/k3d_k3s/outputs.tf
@@ -34,7 +34,7 @@ resource "local_file" "kubeconfig" {
     ]
   })
 
-  filename        = "${path.module}/../../../config/${var.name}.yaml"
+  filename        = "${path.root}/config/${var.name}.yaml"
   file_permission = "0700"
 }
 

--- a/terraform/modules/k3s/outputs.tf
+++ b/terraform/modules/k3s/outputs.tf
@@ -33,7 +33,7 @@ resource "local_file" "kubeconfig" {
     ]
   })
 
-  filename        = "${path.module}/../../../config/${var.name}.yaml"
+  filename        = "${path.root}/config/${var.name}.yaml"
   file_permission = "0700"
 }
 

--- a/terraform/modules/rke/main.tf
+++ b/terraform/modules/rke/main.tf
@@ -39,7 +39,7 @@ resource "local_file" "rke_config" {
     agent_taints         = var.agent_taints
   })
 
-  filename = "${path.module}/../../../config/rke_config/${var.name}.yaml"
+  filename = "${path.root}/config/rke_config/${var.name}.yaml"
 
   provisioner "local-exec" {
     when    = destroy
@@ -59,12 +59,12 @@ resource "null_resource" "rke_up_execution" {
     interpreter = ["bash", "-c"]
     command = templatefile("${path.module}/download_rke.sh", {
       version = split(" ", var.distro_version)[0]
-      target  = "${path.module}/../../../config"
+      target  = "${path.root}/config"
     })
   }
 
   provisioner "local-exec" {
-    command = "${path.module}/../../../config/rke up --config ${path.module}/../../../config/rke_config/${var.name}.yaml"
+    command = "${path.root}/config/rke up --config ${path.root}/config/rke_config/${var.name}.yaml"
   }
 
   triggers = {

--- a/terraform/modules/rke/outputs.tf
+++ b/terraform/modules/rke/outputs.tf
@@ -1,7 +1,7 @@
 data "local_file" "rke_kubeconfig" {
   depends_on = [null_resource.rke_up_execution]
   count      = length(var.server_names) > 0 ? 1 : 0
-  filename   = "${path.module}/../../../config/rke_config/kube_config_${var.name}.yaml"
+  filename   = "${path.root}/config/rke_config/kube_config_${var.name}.yaml"
 }
 
 resource "local_file" "kubeconfig" {
@@ -40,7 +40,7 @@ resource "local_file" "kubeconfig" {
     ]
   })
 
-  filename        = "${path.module}/../../../config/${var.name}.yaml"
+  filename        = "${path.root}/config/${var.name}.yaml"
   file_permission = "0700"
 }
 

--- a/terraform/modules/rke2/outputs.tf
+++ b/terraform/modules/rke2/outputs.tf
@@ -33,7 +33,7 @@ resource "local_file" "kubeconfig" {
     ]
   })
 
-  filename        = "${path.module}/../../../config/${var.name}.yaml"
+  filename        = "${path.root}/config/${var.name}.yaml"
   file_permission = "0700"
 }
 

--- a/terraform/modules/ssh_access/main.tf
+++ b/terraform/modules/ssh_access/main.tf
@@ -11,7 +11,7 @@ resource "local_file" "ssh_script" {
       $@
   EOT
 
-  filename = "${path.module}/../../../config/ssh-to-${var.name}.sh"
+  filename = "${path.root}/config/ssh-to-${var.name}.sh"
 }
 
 resource "local_file" "open_tunnels" {
@@ -25,7 +25,7 @@ resource "local_file" "open_tunnels" {
     ssh_private_key_path = var.ssh_private_key_path
   })
 
-  filename = "${path.module}/../../../config/open-tunnels-to-${var.name}.sh"
+  filename = "${path.root}/config/open-tunnels-to-${var.name}.sh"
 }
 
 resource "null_resource" "open_tunnels" {

--- a/terraform/modules/ssh_host/outputs.tf
+++ b/terraform/modules/ssh_host/outputs.tf
@@ -14,7 +14,7 @@ resource "local_file" "ssh_script" {
       $@
   EOT
 
-  filename = "${path.module}/../../../config/ssh-to-${var.name}.sh"
+  filename = "${path.root}/config/ssh-to-${var.name}.sh"
 }
 
 output "name" {


### PR DESCRIPTION
This allows to maintain multiple configurations in parallel (eg. one console with `TERRAFORM_WORK_DIR=./terraform/main/aws` and another on `TERRAFORM_WORK_DIR=./terraform/main/azure` in parallel).