### PR TITLE
azure: mount ephemeral storage to /data and use it to store rancher data

### DIFF
--- a/terraform/main/azure/inputs.tf
+++ b/terraform/main/azure/inputs.tf
@@ -10,7 +10,7 @@ locals {
 
     // azure-specific
     local_name = "upstream.local.gd"
-    size       = "Standard_B4as_v2"
+    size       = "Standard_E2ads_v5"
     os_image = {
       publisher = "suse"
       offer     = "opensuse-leap-15-5"

--- a/terraform/modules/azure_host/main.tf
+++ b/terraform/modules/azure_host/main.tf
@@ -55,6 +55,10 @@ resource "null_resource" "host_configuration" {
   }
 
   provisioner "remote-exec" {
+    script = "${path.module}/mount_ephemeral.sh"
+  }
+
+  provisioner "remote-exec" {
     inline = var.host_configuration_commands
   }
 }

--- a/terraform/modules/azure_host/mount_ephemeral.sh
+++ b/terraform/modules/azure_host/mount_ephemeral.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -xe
+
+# Azure ephemeral local disk are mounted by default on /mnt and formatted as ext4
+# let's re-format as xfs and mount on /data
+partition=$(findmnt -nM /mnt | awk '{print $2}')
+case "$partition" in
+  "/dev/sd"*)
+    sudo umount /mnt
+    sudo /sbin/mkfs.xfs -f ${partition}
+    sudo mkdir -p /data
+    sudo mount ${partition} /data
+    ;;
+esac

--- a/terraform/modules/rke2/install_rke2.sh
+++ b/terraform/modules/rke2/install_rke2.sh
@@ -6,6 +6,12 @@ set -xe
 sleep ${sleep_time}
 
 sudo -s <<SUDO
+# use data disk if available (see mount_ephemeral.sh)
+if [ -d /data ]; then
+  mkdir -p /data/rancher
+  ln -sf /data/rancher /var/lib/rancher
+fi
+
 # https://docs.rke2.io/known_issues/#networkmanager
 if systemctl status NetworkManager; then
   cat >/etc/NetworkManager/conf.d/rke2-canal.conf <<EOF


### PR DESCRIPTION
This is a minimal PR to enable automatic usage of the ephemeral (temporary) storage for mounting rancher data (in particular etcd storage).
Ephemeral volumes are not persistent but offer high write speeds.

Changed also the sample VM "size" for the upstream cluster, in order to pick up one with available ephemeral storage.