### PR TITLE
azure: allow provisioning of "spot" instances (optional)

### DIFF
--- a/terraform/main/azure/main.tf
+++ b/terraform/main/azure/main.tf
@@ -76,6 +76,7 @@ module "k3s_cluster" {
   local_https_port          = local.first_local_https_port + count.index
   os_image                  = local.k3s_clusters[count.index].os_image
   size                      = local.k3s_clusters[count.index].size
+  is_spot                   = lookup(local.k3s_clusters[count.index], "is_spot", false)
   os_disk_type              = lookup(local.k3s_clusters[count.index], "os_disk_type", "Standard_LRS")
   os_disk_size              = lookup(local.k3s_clusters[count.index], "os_disk_size", 30)
   resource_group_name       = azurerm_resource_group.rg.name
@@ -111,6 +112,7 @@ module "rke2_cluster" {
   local_https_port          = local.first_local_https_port + length(local.k3s_clusters) + count.index
   os_image                  = local.rke2_clusters[count.index].os_image
   size                      = local.rke2_clusters[count.index].size
+  is_spot                   = lookup(local.rke2_clusters[count.index], "is_spot", false)
   os_disk_type              = lookup(local.rke2_clusters[count.index], "os_disk_type", "Standard_LRS")
   os_disk_size              = lookup(local.rke2_clusters[count.index], "os_disk_size", 30)
   resource_group_name       = azurerm_resource_group.rg.name

--- a/terraform/modules/azure_host/input.tf
+++ b/terraform/modules/azure_host/input.tf
@@ -33,11 +33,11 @@ variable "size" {
   default     = "Standard_B2as_v2"
 }
 
-// Spot instances can be Deallocated/Deleted but costs 1/10th
+// Spot instances can be Deallocated/Deleted but can costs 90% less
 // anyway, seems we have a constraint that only 3 cores can be allocated as Spot instances
 // causing provisioning of many nodes to fail
 variable "is_spot" {
-  description = "Wheter the VM should be allocated as a Spot instance (costs 1/10th of regular ones but could be evicted)"
+  description = "Wheter the VM should be allocated as a Spot instance (can cost 90% less of regular ones but could be evicted)"
   default     = false
 }
 

--- a/terraform/modules/azure_host/main.tf
+++ b/terraform/modules/azure_host/main.tf
@@ -17,6 +17,7 @@ resource "azurerm_linux_virtual_machine" "main" {
   location              = var.location
   size                  = var.size
   priority              = var.is_spot ? "Spot" : "Regular"
+  eviction_policy       = var.is_spot ? "Deallocate" : null
   admin_username        = var.ssh_user
   network_interface_ids = [azurerm_network_interface.nic.id]
 

--- a/terraform/modules/azure_k3s/input.tf
+++ b/terraform/modules/azure_k3s/input.tf
@@ -65,6 +65,11 @@ variable "size" {
   default     = "Standard_B2as_v2"
 }
 
+variable "is_spot" {
+  description = "Wheter the VM should be allocated as a Spot instance (can cost 90% less of regular ones but could be evicted)"
+  default     = false
+}
+
 variable "ssh_user" {
   description = "Azure VM admin user name used for ssh access"
   default     = "azureuser"

--- a/terraform/modules/azure_k3s/main.tf
+++ b/terraform/modules/azure_k3s/main.tf
@@ -7,6 +7,7 @@ module "server_nodes" {
   location             = var.location
   resource_group_name  = var.resource_group_name
   size                 = var.size
+  is_spot              = var.is_spot
   project_name         = var.project_name
   name                 = "${var.name}-server-${count.index}"
   ssh_public_key_path  = var.ssh_public_key_path
@@ -31,6 +32,7 @@ module "agent_nodes" {
   location                    = var.location
   resource_group_name         = var.resource_group_name
   size                        = var.size
+  is_spot                     = var.is_spot
   project_name                = var.project_name
   name                        = "${var.name}-agent-${count.index}"
   ssh_public_key_path         = var.ssh_public_key_path

--- a/terraform/modules/azure_rke2/input.tf
+++ b/terraform/modules/azure_rke2/input.tf
@@ -65,6 +65,11 @@ variable "size" {
   default     = "Standard_B2as_v2"
 }
 
+variable "is_spot" {
+  description = "Wheter the VM should be allocated as a Spot instance (can cost 90% less of regular ones but could be evicted)"
+  default     = false
+}
+
 variable "ssh_user" {
   description = "Azure VM admin user name used for ssh access"
   default     = "azureuser"

--- a/terraform/modules/azure_rke2/main.tf
+++ b/terraform/modules/azure_rke2/main.tf
@@ -7,6 +7,7 @@ module "server_nodes" {
   location             = var.location
   resource_group_name  = var.resource_group_name
   size                 = var.size
+  is_spot              = var.is_spot
   project_name         = var.project_name
   name                 = "${var.name}-server-${count.index}"
   ssh_public_key_path  = var.ssh_public_key_path
@@ -31,6 +32,7 @@ module "agent_nodes" {
   location                    = var.location
   resource_group_name         = var.resource_group_name
   size                        = var.size
+  is_spot                     = var.is_spot
   project_name                = var.project_name
   name                        = "${var.name}-agent-${count.index}"
   ssh_public_key_path         = var.ssh_public_key_path


### PR DESCRIPTION
can be evicted at any time, but can cost 90% less.
Handy for micro provisioning tests (3 vcpu is the current limit x region, so one VM with 2 cores max will be fine).
You need a VM size supporting Spot instances or would fail.
Option is per cluster: "is_spot=true", disabled by default.