### PR TITLE
azure/trivial: update azurerm provider to 3.82.0

### DIFF
--- a/terraform/main/azure/main.tf
+++ b/terraform/main/azure/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.0.2"
+      version = "3.82.0"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
The terraform azurerm latest release is v. 3.82.0.
3.82.0 is also the latest released one at [opentofu](https://github.com/opentofu/terraform-provider-azurerm/releases/tag/v3.82.0).