### PR TITLE
AKS: raise the number of maximum pods per node

### DIFF
--- a/terraform/modules/azure_aks/main.tf
+++ b/terraform/modules/azure_aks/main.tf
@@ -16,12 +16,14 @@ resource "azurerm_kubernetes_cluster" "cluster" {
   }
 
   default_node_pool {
-    name            = "default"
-    node_count      = var.default_node_pool_count
-    vm_size         = var.vm_size
-    vnet_subnet_id  = var.subnet_id
-    os_disk_type    = var.os_ephemeral_disk ? "Ephemeral" : "Managed"
-    os_disk_size_gb = var.os_disk_size
+    name                        = "default"
+    temporary_name_for_rotation = "tempdefault"
+    node_count                  = var.default_node_pool_count
+    vm_size                     = var.vm_size
+    vnet_subnet_id              = var.subnet_id
+    os_disk_type                = var.os_ephemeral_disk ? "Ephemeral" : "Managed"
+    os_disk_size_gb             = var.os_disk_size
+    max_pods                    = 250
   }
 
   identity {
@@ -39,6 +41,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "secondary" {
   vnet_subnet_id        = var.subnet_id
   os_disk_type          = var.os_ephemeral_disk ? "Ephemeral" : "Managed"
   os_disk_size_gb       = var.os_disk_size
+  max_pods              = 250
 }
 
 resource "local_file" "kubeconfig" {


### PR DESCRIPTION
During a simple test of the node inspection instructions (https://learn.microsoft.com/en-us/azure/aks/node-access#ssh-using-kubectl-debug) I stumbled upon an `OutOfPods` condition.

Figured out maxing out is a better default value


https://learn.microsoft.com/en-us/azure/aks/azure-cni-overview#maximum-pods-per-node

Also added: an option to make default nodepool migration working when this parameter changes