### PR TITLE
terraform/aks: fix 'node_access_commands' format

### DIFF
--- a/terraform/modules/azure_aks/output.tf
+++ b/terraform/modules/azure_aks/output.tf
@@ -11,7 +11,7 @@ output "cluster_public_name" {
 }
 
 output "node_access_commands" {
-  value = []
+  value = {}
 }
 
 output "ingress_class_name" {


### PR DESCRIPTION
We need a collection there (we have it as a collection in all the other modules): let's fix it!