### PR TITLE
terraform/k3d: set 'node_access_commands' as an empty map

### DIFF
--- a/terraform/main/k3d/outputs.tf
+++ b/terraform/main/k3d/outputs.tf
@@ -26,7 +26,7 @@ output "clusters" {
         }
       }
 
-      node_access_commands = []
+      node_access_commands = {}
       ingress_class_name   = null
     }
   }


### PR DESCRIPTION
The 'node_access_commands' is returned as a Map/Object from the terraform modules to map each node to a script to access it.
We return an empty one from k3d, as we don't really provide access scripts for nodes there, but since the parameter is expected we pass an empty List. Anyway, to be coherent with the other modules, we should pass an empty Map (otherwise go unmarshalling complains).