### PR TITLE
Replace Terraform with OpenTofu

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -2,27 +2,27 @@
 
 ## Overall architecture
 
- - Terraform is used to deploy infrastructure. That includes all is necessary in order to launch Kubernetes clusters - modules should conclude producing a kubeconfig file and context
-   - `tf` files in `terraform/main/` specify whole testing environments
-   - `tf` files in `terraform/modules/` implement components (platform-specific or platform-agnostic)
- - the `bin/setup.mjs ` node.js script runs Terraform to create Kubernetes clusters, then Helm/kubectl to deploy and configure software under test (Rancher and/or any other component). It is designed to be idempotent
+ - OpenTofu is used to deploy infrastructure. That includes all is necessary in order to launch Kubernetes clusters - modules should conclude producing a kubeconfig file and context
+   - `tf` files in `tofu/main/` specify whole testing environments
+   - `tf` files in `tofu/modules/` implement components (platform-specific or platform-agnostic)
+ - the `bin/setup.mjs ` node.js script runs OpenTofu to create Kubernetes clusters, then Helm/kubectl to deploy and configure software under test (Rancher and/or any other component). It is designed to be idempotent
  - the `bin/run_tests.mjs ` node.js script runs `k6` scripts in `k6/`, generating load. It is designed to be idempotent
  - a Mimir-backed Grafana instance in an own cluster displays results and acts as long-term result storage
 
-## Porting Terraform files to new platforms
+## Porting OpenTofu files to new platforms
 
- - create a new `terraform/main` subdirectory copying over `tf` files from `aws`
+ - create a new `tofu/main` subdirectory copying over `tf` files from `aws`
  - edit `inputs.tf` to include any platform-specific information
  - edit `main.tf` to use platform-specific providers, add modules as appropriate
-   - platform-specific modules are prefixed with the platform name (eg. `terraform/modules/aws_*`)
+   - platform-specific modules are prefixed with the platform name (eg. `tofu/modules/aws_*`)
    - platform-agnostic modules are not prefixed
    - platform-specific wrappers are normally created for platform-agnostic modules (eg. `aws_k3s` wraps `k3s`)
  - adapt `outputs.tf` - please note the exact structure is expected by scripts in `bin/` - change with care
 
-It is assumed all created clusters will be able to reach one another with the same domain names, from the same network. That network might not be the same network of the machine running Terraform.
+It is assumed all created clusters will be able to reach one another with the same domain names, from the same network. That network might not be the same network of the machine running OpenTofu.
 
-Created clusters may or may not be directly reachable from the machine running Terraform. In the current `aws` implementation, for example, all access goes through an SSH bastion host and tunnels, but that is an implementation detail and may change in future. For new platforms there is no requirement - clusters might be directly reachable with an Internet-accessible FQDN, or be behind a bastion host, Tailscale, Boundary or other mechanism. Structures in `outputs.tf` have been designed to accommodate for all cases, in particular:
- - `local_` variables refer to domain names and ports as used by the machine running Terraform,
+Created clusters may or may not be directly reachable from the machine running OpenTofu. In the current `aws` implementation, for example, all access goes through an SSH bastion host and tunnels, but that is an implementation detail and may change in future. For new platforms there is no requirement - clusters might be directly reachable with an Internet-accessible FQDN, or be behind a bastion host, Tailscale, Boundary or other mechanism. Structures in `outputs.tf` have been designed to accommodate for all cases, in particular:
+ - `local_` variables refer to domain names and ports as used by the machine running OpenTofu,
  - `private_` variables refer to domain names and ports as used by the clusters in their network,
  - values may coincide.
 
@@ -35,7 +35,7 @@ export TERRAFORM_WORK_DIR=terraform/main/aws
 ./bin/teardown.mjs && ./bin/setup.mjs && ./bin/run_tests.mjs
 ```
 
-See `terraform/main` subdirectories for the currently available platforms.
+See `tofu/main` subdirectories for the currently available platforms.
 
 ## Hacks and workarounds
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See the [docs](docs) directory for a list of tests and their usage specifics.
 
 ### k3d: cluster not created
 
-If you get this error from `terraform apply`:
+If you get this error from `tofu apply`:
 ```
 Error: Failed Cluster Start: Failed to add one or more agents: Node k3d-... failed to get ready: error waiting for log line `successfully registered node` from node 'k3d-st-upstream-agent-0': stopped returning log lines: node k3d-... is running=true in status=restarting
 ```
@@ -28,7 +28,7 @@ echo "fs.inotify.max_user_instances = 256" > /etc/sysctl.d/99-inotify-mui.conf
 
 ### Kubernetes cluster unreachable
 
-If you get this error from `terraform apply`:
+If you get this error from `tofu apply`:
 ```
 │ Error: Kubernetes cluster unreachable: Get "https://upstream.local.gd:6443/version": dial tcp 127.0.0.1:6443: connect: connection refused
 ```
@@ -38,9 +38,9 @@ SSH tunnels might be broken. Reopen them via:
 ./config/open-tunnels-to-upstream-*.sh
 ```
 
-### Terraform extended logging
+### OpenTofu extended logging
 
-In case Terraform returns an error with little context about what happened, use the following to get more complete debugging output:
+In case OpenTofu returns an error with little context about what happened, use the following to get more complete debugging output:
 ```shell
 export TF_LOG=debug
 ```
@@ -89,9 +89,9 @@ When using `k3d`, change `RANCHER_IMAGE_TAG` and if an image with the same tag i
 
 This is useful during Rancher development to test Rancher changes on k3d clusters.
 
-## Passing custom Terraform variables
+## Passing custom OpenTofu variables
 
-Terraform variables can be overridden using `TERRAFORM_VAR_FILE` environment variable, to point to a [`.tfvars` file](https://developer.hashicorp.com/terraform/language/values/variables#variable-definitions-tfvars-files). The variable should contain a path to the file in json or tfvars format.
+OpenTofu variables can be overridden using `TERRAFORM_VAR_FILE` environment variable, to point to a [`.tfvars` file](https://developer.hashicorp.com/tofu/language/values/variables#variable-definitions-tfvars-files). The variable should contain a path to the file in json or tfvars format.
 For example, for the `ssh` module, nodes' ip addresses, login name, etc. can be overridden as follows:
 
 ```shell

--- a/bin/get_access.mjs
+++ b/bin/get_access.mjs
@@ -11,7 +11,7 @@ import {
 } from "./lib/common.mjs"
 import {k6_run} from "./lib/k6.mjs"
 
-const clusters = runCollectingJSONOutput(`terraform -chdir=${terraformDir()} output -json`)["clusters"]["value"]
+const clusters = runCollectingJSONOutput(`tofu -chdir=${terraformDir()} output -json`)["clusters"]["value"]
 
 const upstream = clusters["upstream"]
 const upstreamAddresses = getAppAddressesFor(upstream)

--- a/bin/lib/common.mjs
+++ b/bin/lib/common.mjs
@@ -86,7 +86,7 @@ export function getAppAddressesFor(cluster) {
     const addresses = cluster["app_addresses"]
     const loadBalancerName = guessAppFQDNFromLoadBalancer(cluster)
 
-    // addresses meant to be resolved from the machine running Terraform
+    // addresses meant to be resolved from the machine running OpenTofu
     // use tunnel if available, otherwise public, otherwise go through the load balancer
     const localNetworkName = addresses["tunnel"]["name"] || addresses["public"]["name"] || loadBalancerName
     const localNetworkHTTPPort = addresses["tunnel"]["http_port"] || addresses["public"]["http_port"] || 80

--- a/bin/run_tests.mjs
+++ b/bin/run_tests.mjs
@@ -20,7 +20,7 @@ const USER_COUNT = 5
 const PROJECT_COUNT = 20
 
 // Refresh k6 files on the tester cluster
-const clusters = runCollectingJSONOutput(`terraform -chdir=${terraformDir()} output -json`)["clusters"]["value"]
+const clusters = runCollectingJSONOutput(`tofu -chdir=${terraformDir()} output -json`)["clusters"]["value"]
 const tester = clusters["tester"]
 helm_install("k6-files", dir("charts/k6-files"), tester, "tester", {})
 

--- a/bin/setup.mjs
+++ b/bin/setup.mjs
@@ -24,10 +24,10 @@ const RANCHER_IMAGE_TAG = `v${RANCHER_VERSION}`
 const CERT_MANAGER_CHART = "https://charts.jetstack.io/charts/cert-manager-v1.8.0.tgz"
 const GRAFANA_CHART = "https://github.com/grafana/helm-charts/releases/download/grafana-6.56.5/grafana-6.56.5.tgz"
 
-// Step 1: Terraform
-run(`terraform -chdir=${q(terraformDir())} init -upgrade`)
-run(`terraform -chdir=${q(terraformDir())} apply -auto-approve ${q(terraformVar())}`)
-const clusters = runCollectingJSONOutput(`terraform -chdir=${q(terraformDir())} output -json`)["clusters"]["value"]
+// Step 1: OpenTofu
+run(`tofu -chdir=${q(terraformDir())} init -upgrade`)
+run(`tofu -chdir=${q(terraformDir())} apply -auto-approve ${q(terraformVar())}`)
+const clusters = runCollectingJSONOutput(`tofu -chdir=${q(terraformDir())} output -json`)["clusters"]["value"]
 
 // Step 3: Helm charts
 // tester cluster

--- a/bin/teardown.mjs
+++ b/bin/teardown.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 import {terraformDir, terraformVar, q, run} from "./lib/common.mjs"
 
-run(`terraform -chdir=${q(terraformDir())} init -upgrade`)
-run(`terraform -chdir=${q(terraformDir())} destroy -auto-approve ${q(terraformVar())}`)
+run(`tofu -chdir=${q(terraformDir())} init -upgrade`)
+run(`tofu -chdir=${q(terraformDir())} destroy -auto-approve ${q(terraformVar())}`)

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -55,7 +55,7 @@ type Terraform struct {
 const DefaultThreads = 10
 
 func (t *Terraform) Init(dir string, verbose bool) error {
-	tfBinary, err := exec.LookPath("terraform")
+	tfBinary, err := exec.LookPath("tofu")
 	if err != nil {
 		return fmt.Errorf("error: terraform init: %w", err)
 	}

--- a/terraform/main/aks/main.tf
+++ b/terraform/main/aks/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.5.7"
+  required_version = "1.6.2"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/terraform/main/aks/outputs.tf
+++ b/terraform/main/aks/outputs.tf
@@ -18,7 +18,7 @@ locals {
         http_port  = 80
         https_port = 443
       }
-      tunnel = { // resolvable from the host running Terraform
+      tunnel = { // resolvable from the host running OpenTofu
         name       = "${cluster.name}.local.gd"
         http_port  = module.k3s_cluster[i].tunnel_app_http_port
         https_port = module.k3s_cluster[i].tunnel_app_https_port
@@ -48,7 +48,7 @@ locals {
         http_port  = 80
         https_port = 443
       }
-      tunnel = { // resolvable from the host running Terraform
+      tunnel = { // resolvable from the host running OpenTofu
         name       = "${cluster.name}.local.gd"
         http_port  = module.rke2_cluster[i].tunnel_app_http_port
         https_port = module.rke2_cluster[i].tunnel_app_https_port
@@ -69,7 +69,7 @@ locals {
     // addresses of applications running in this cluster
     app_addresses = {
       public = {          // resolvable over the Internet
-        name       = null // not known at the Terraform stage, will depend on LoadBalancers in Kubernetes
+        name       = null // not known at the OpenTofu stage, will depend on LoadBalancers in Kubernetes
         http_port  = null
         https_port = null
       }
@@ -78,7 +78,7 @@ locals {
         http_port  = null
         https_port = null
       }
-      tunnel = {          // resolvable from the host running Terraform
+      tunnel = {          // resolvable from the host running OpenTofu
         name       = null // tunnels not supported
         http_port  = null
         https_port = null

--- a/terraform/main/aws/main.tf
+++ b/terraform/main/aws/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.5.7"
+  required_version = "1.6.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/main/aws/outputs.tf
+++ b/terraform/main/aws/outputs.tf
@@ -18,7 +18,7 @@ locals {
         http_port  = 80
         https_port = 443
       }
-      tunnel = { // resolvable from the host running Terraform
+      tunnel = { // resolvable from the host running OpenTofu
         name       = "${cluster.name}.local.gd"
         http_port  = module.k3s_cluster[i].tunnel_app_http_port
         https_port = module.k3s_cluster[i].tunnel_app_https_port
@@ -48,7 +48,7 @@ locals {
         http_port  = 80
         https_port = 443
       }
-      tunnel = { // resolvable from the host running Terraform
+      tunnel = { // resolvable from the host running OpenTofu
         name       = "${cluster.name}.local.gd"
         http_port  = module.rke_cluster[i].tunnel_app_http_port
         https_port = module.rke_cluster[i].tunnel_app_https_port
@@ -78,7 +78,7 @@ locals {
         http_port  = 80
         https_port = 443
       }
-      tunnel = { // resolvable from the host running Terraform
+      tunnel = { // resolvable from the host running OpenTofu
         name       = "${cluster.name}.local.gd"
         http_port  = module.rke2_cluster[i].tunnel_app_http_port
         https_port = module.rke2_cluster[i].tunnel_app_https_port

--- a/terraform/main/azure/main.tf
+++ b/terraform/main/azure/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.5.7"
+  required_version = "1.6.2"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/terraform/main/azure/outputs.tf
+++ b/terraform/main/azure/outputs.tf
@@ -18,7 +18,7 @@ locals {
         http_port  = 80
         https_port = 443
       }
-      tunnel = { // resolvable from the host running Terraform
+      tunnel = { // resolvable from the host running OpenTofu
         name       = "${cluster.name}.local.gd"
         http_port  = module.k3s_cluster[i].tunnel_app_http_port
         https_port = module.k3s_cluster[i].tunnel_app_https_port
@@ -48,7 +48,7 @@ locals {
         http_port  = 80
         https_port = 443
       }
-      tunnel = { // resolvable from the host running Terraform
+      tunnel = { // resolvable from the host running OpenTofu
         name       = "${cluster.name}.local.gd"
         http_port  = module.rke2_cluster[i].tunnel_app_http_port
         https_port = module.rke2_cluster[i].tunnel_app_https_port
@@ -69,7 +69,7 @@ locals {
     // addresses of applications running in this cluster
     app_addresses = {
       public = {          // resolvable over the Internet
-        name       = null // not known at the Terraform stage, will depend on LoadBalancers in Kubernetes
+        name       = null // not known at the OpenTofu stage, will depend on LoadBalancers in Kubernetes
         http_port  = null
         https_port = null
       }
@@ -78,7 +78,7 @@ locals {
         http_port  = null
         https_port = null
       }
-      tunnel = {          // resolvable from the host running Terraform
+      tunnel = {          // resolvable from the host running OpenTofu
         name       = null // tunnels not supported
         http_port  = null
         https_port = null

--- a/terraform/main/k3d/main.tf
+++ b/terraform/main/k3d/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.5.7"
+  required_version = "1.6.2"
   required_providers {
     docker = {
       source  = "kreuzwerker/docker"

--- a/terraform/main/k3d/outputs.tf
+++ b/terraform/main/k3d/outputs.tf
@@ -19,7 +19,7 @@ output "clusters" {
           http_port  = 80
           https_port = 443
         }
-        tunnel = { // resolvable from the host running Terraform
+        tunnel = { // resolvable from the host running OpenTofu
           name       = "${cluster.name}.local.gd"
           http_port  = module.cluster[i].app_http_port
           https_port = module.cluster[i].app_https_port

--- a/terraform/main/openstack/README.md
+++ b/terraform/main/openstack/README.md
@@ -18,7 +18,7 @@
 ## Not yet implemented
 Octavia (loadbalancer) server nodes. Currently, floating IPs are attached to the first server node only.
 
-This set of Terraform files has been tested so far on the OVHcloud OpenStack implementation.
+This set of OpenTofu files has been tested so far on the OVHcloud OpenStack implementation.
 
 ## Usage
 
@@ -26,5 +26,5 @@ Deployment only:
 ```shell
 source ./openrc.bash # OpenStack Credentials
 vim input.tf         # Tweak parameters
-terraform apply      # Deploy (Terraform only). ./bin/setup.mjs can be used to set up the test suite
+tofu apply      # Deploy (Terraform only). ./bin/setup.mjs can be used to set up the test suite
 ```

--- a/terraform/main/openstack/main.tf
+++ b/terraform/main/openstack/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.5.7"
+  required_version = "1.6.2"
   required_providers {
     openstack = {
       source  = "terraform-provider-openstack/openstack"

--- a/terraform/main/openstack/outputs.tf
+++ b/terraform/main/openstack/outputs.tf
@@ -19,7 +19,7 @@ output "clusters" {
           http_port  = null
           https_port = null
         }
-        tunnel = {          // resolvable from the host running Terraform
+        tunnel = {          // resolvable from the host running OpenTofu
           name       = null // tunnels not supported
           http_port  = null
           https_port = null

--- a/terraform/main/ssh/main.tf
+++ b/terraform/main/ssh/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.5.7"
+  required_version = "1.6.2"
   required_providers {
     tls = {
       source  = "hashicorp/tls"

--- a/terraform/main/ssh/outputs.tf
+++ b/terraform/main/ssh/outputs.tf
@@ -19,7 +19,7 @@ output "clusters" {
           http_port  = null
           https_port = null
         }
-        tunnel = {          // resolvable from the host running Terraform
+        tunnel = {          // resolvable from the host running OpenTofu
           name       = null // tunnels not supported
           http_port  = null
           https_port = null


### PR DESCRIPTION
@fgiudici can you take a look as into what to rename/refactor in go code?

for now we will keep using tf-exec as it is. tofu-exec exists but it's broken now, and it provides no benefit at the moment