### PR TITLE
fix(aks): bump Kubernetes to supported version

### DIFF
--- a/terraform/main/aks/inputs.tf
+++ b/terraform/main/aks/inputs.tf
@@ -4,7 +4,7 @@ locals {
   upstream_cluster = {
     name                        = "upstream"
     agent_count                 = 4
-    distro_version              = "1.27.7"
+    distro_version              = "1.27.13"
     reserve_node_for_monitoring = true
 
     // azure-specific
@@ -39,7 +39,7 @@ locals {
     {
       name                        = "downstream-${i}"
       agent_count                 = 1
-      distro_version              = "1.27.7"
+      distro_version              = "1.27.13"
       reserve_node_for_monitoring = false
 
       // azure-specific


### PR DESCRIPTION
Fixes this error:
```
╷
│ Error: creating Kubernetes Cluster (Subscription: "..."
│ Resource Group Name: "st-rg"
│ Kubernetes Cluster Name: "st-upstream"): managedclusters.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="AgentPoolK8sVersionNotSupported" Message="Version 1.27.7 is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list"
│
│   with module.aks_cluster[0].azurerm_kubernetes_cluster.cluster,
│   on ../../modules/azure_aks/main.tf line 1, in resource "azurerm_kubernetes_cluster" "cluster":
│    1: resource "azurerm_kubernetes_cluster" "cluster" {
│
╵
```
v1.27.13 is the latest 1.27 available according to https://github.com/Azure/AKS/releases/tag/2024-06-09